### PR TITLE
Simplify the `ReadEfuse` trait

### DIFF
--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -319,16 +319,6 @@ impl Target for Esp32 {
         );
 
         IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, params)
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -1,15 +1,13 @@
-#[cfg(feature = "serialport")]
-use std::collections::HashMap;
-use std::ops::Range;
+use std::{collections::HashMap, ops::Range};
 
 use log::debug;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -170,17 +168,6 @@ impl Target for Esp32c2 {
         );
 
         IdfBootloaderFormat::new(elf_data, Chip::Esp32c2, flash_data, params)
-    }
-
-    #[cfg(feature = "serialport")]
-    /// What is the MAC address?
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -167,16 +167,6 @@ impl Target for Esp32c3 {
             "riscv32imc-esp-espidf",
             "riscv32imc-unknown-none-elf",
         ]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }
 

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -158,15 +158,5 @@ impl Target for Esp32c6 {
 
     fn supported_build_targets(&self) -> &[&str] {
         &["riscv32imac-esp-espidf", "riscv32imac-unknown-none-elf"]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, ops::Range};
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -163,15 +163,5 @@ impl Target for Esp32h2 {
 
     fn supported_build_targets(&self) -> &[&str] {
         &["riscv32imac-esp-espidf", "riscv32imac-unknown-none-elf"]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -147,16 +147,6 @@ impl Target for Esp32p4 {
 
     fn supported_build_targets(&self) -> &[&str] {
         &["riscv32imafc-esp-espidf", "riscv32imafc-unknown-none-elf"]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }
 

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,11 +5,11 @@ use std::ops::Range;
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
 #[cfg(feature = "serialport")]
-use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
+use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -258,16 +258,6 @@ impl Target for Esp32s2 {
 
     fn supported_build_targets(&self) -> &[&str] {
         &["xtensa-esp32s2-none-elf", "xtensa-esp32s2-espidf"]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }
 

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::ops::Range;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, targets::EfuseField};
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, EfuseField, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
+    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
 
@@ -202,16 +202,6 @@ impl Target for Esp32s3 {
 
     fn supported_build_targets(&self) -> &[&str] {
         &["xtensa-esp32s3-none-elf", "xtensa-esp32s3-espidf"]
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let fields = self.common_fields();
-        self.read_mac_address_from_words(
-            connection,
-            fields["MAC_FACTORY_0"],
-            fields["MAC_FACTORY_1"],
-        )
     }
 }
 


### PR DESCRIPTION
Just some simplification/cleanup. Hopefully nothing too controversial here, but let me know if you'd like any changes made of course.